### PR TITLE
Binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,7 +3,6 @@ wasabi>=0.6.0,<1.1.0
 srsly>=0.0.5,<1.1.0
 pytest>=4.4.1,<4.5.0
 black==19.10b0
-Sudachipy==0.4.9
 
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz#egg=en_core_web_sm==2.3.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.3.0/en_core_web_md-2.3.0.tar.gz#egg=en_core_web_md==2.3.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,13 +3,16 @@ wasabi>=0.6.0,<1.1.0
 srsly>=0.0.5,<1.1.0
 pytest>=4.4.1,<4.5.0
 black==19.10b0
+Sudachipy==0.4.9
 
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz#egg=en_core_web_sm==2.3.1
-https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.3.0/en_core_web_md-2.3.0.tar.gz#egg=en_core_web_md==2.3.1
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz#egg=en_core_web_sm==2.3.0
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.3.0/en_core_web_md-2.3.0.tar.gz#egg=en_core_web_md==2.3.0
 https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.3.0/de_core_news_sm-2.3.0.tar.gz#egg=de_core_news_sm==2.3.0
-https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-2.3.0/es_core_news_sm-2.3.0.tar.gz#egg=es_core_news_sm==2.3.1
-https://github.com/explosion/spacy-models/releases/download/es_core_news_md-2.3.0/es_core_news_md-2.3.0.tar.gz#egg=es_core_news_md==2.3.1
+https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-2.3.0/es_core_news_sm-2.3.0.tar.gz#egg=es_core_news_sm==2.3.0
+https://github.com/explosion/spacy-models/releases/download/es_core_news_md-2.3.0/es_core_news_md-2.3.0.tar.gz#egg=es_core_news_md==2.3.0
 https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-2.3.0/fr_core_news_sm-2.3.0.tar.gz#egg=fr_core_news_sm==2.3.0
 https://github.com/explosion/spacy-models/releases/download/fr_core_news_md-2.3.0/fr_core_news_md-2.3.0.tar.gz#egg=fr_core_news_md==2.3.0
 https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-2.3.1/zh_core_web_sm-2.3.1.tar.gz#egg=zh_core_web_sm==2.3.1
 https://github.com/explosion/spacy-models/releases/download/zh_core_web_md-2.3.1/zh_core_web_md-2.3.1.tar.gz#egg=zh_core_web_md==2.3.1
+https://github.com/explosion/spacy-models/releases/download/ja_core_news_sm-2.3.2/ja_core_news_sm-2.3.2.tar.gz#egg=ja_core_news_sm==2.3.2
+https://github.com/explosion/spacy-models/releases/download/ja_core_news_md-2.3.2/ja_core_news_md-2.3.2.tar.gz#egg=ja_core_news_md==2.3.2

--- a/meta.json
+++ b/meta.json
@@ -6,7 +6,7 @@
     "testTemplate": "from wasabi import msg\nimport warnings\nfrom black import format_str, FileMode\n\nwarnings.filterwarnings('ignore', message=r'\\[W033\\]', category=UserWarning)\nfile_mode = FileMode()\n\ndef blacken(code):\n    try:\n        return format_str(code, mode=file_mode)\n    except:\n        return code\n\n__msg__ = msg\n__solution__ = blacken(\"\"\"${solution}\"\"\")\n\n${solution}\n\n${test}\n\ntry:\n    test()\nexcept AssertionError as e:\n    __msg__.fail(e)",
     "pytestTemplate": "from wasabi import msg\nimport warnings\nfrom black import format_str, FileMode\n\nwarnings.filterwarnings('ignore', message=r'\\[W033\\]', category=UserWarning)\nfile_mode = FileMode()\n\ndef blacken(code):\n    try:\n        return format_str(code, mode=file_mode)\n    except:\n        return code\n\n__msg__ = msg\n__solution__ = blacken(\"\"\"${solution}\"\"\")\n\n${solution}\n\n${test}\n\ntest()",
     "juniper": {
-        "repo": "ines/spacy-course",
+        "repo": "hiroshi-matsuda-rit/spacy-course",
         "branch": "binder",
         "kernelType": "python3",
         "debug": false


### PR DESCRIPTION
- Sudachipyの追加
- japaneseモデルの追加
- 臨時でbinderのレポをこのレポに変更（本家にPRを出す際に更新します）
- binderビルド済み。正しく実行されることを確認済み。

このPRによって演習コードの実行環境にsudachipyと日本語モデルがインストールされます。
もし以前にspacy-courseをローカルで実行している場合は、localstorageに古いバージョンの実行環境情報が埋め込まれている影響でうまくいかないかもしれません。その場合は、devtoolsでlocalstorageの内容を消してください。